### PR TITLE
[ADD] 데이트 장소 등록

### DIFF
--- a/db/migrations/20230114061738_create_dates_table.sql
+++ b/db/migrations/20230114061738_create_dates_table.sql
@@ -7,7 +7,7 @@ CREATE TABLE date (
     user_id INT NOT NULL,
     opentime TIME,
     closetime TIME,
-    desciption TEXT,
+    description TEXT,
     created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 );

--- a/src/controllers/dateController.js
+++ b/src/controllers/dateController.js
@@ -1,0 +1,33 @@
+const dateService = require('../services/dateService')
+
+const postDate = async (req,res) => {
+    try{
+        const {name, location, main_img, user_id, opentime, closetime, description} = req.body;
+        if ( !name || !location || !user_id || !description) {
+            return res.status(400).json({ message: "필수정보를 입력하시지 않았습니다." });
+            };
+        await dateService.postDate(name, location, main_img, user_id, opentime, closetime, description);
+        res.status(201).json({ message: "데이트장소가 등록되었습니다." });
+    } catch (err) {
+        res
+        .status(err.statusCode ? err.statusCode : 400)
+        .json({ message: err.message });
+    }
+};
+
+const postCategory = async (req,res) => {
+    try{
+        const {category_id} = req.body;
+        await dateService.postCategory(category_id);
+        res.status(201).json({ message: "카테고리가 등록되었습니다." });
+    } catch (err) {
+        res
+        .status(err.statusCode ? err.statusCode : 400)
+        .json({ message: err.message });
+    }
+};
+
+module.exports = {
+    postDate,
+    postCategory,
+};

--- a/src/models/dateDao.js
+++ b/src/models/dateDao.js
@@ -1,0 +1,82 @@
+const { AppDataSource } = require("../models/dataSource");
+
+const postDate = async (name, location, main_img, user_id, opentime, closetime, description) => {
+    try {
+		return await AppDataSource.query(
+			`INSERT INTO date(
+		    	name, 
+            	location, 
+            	main_img, 
+            	user_id, 
+            	opentime, 
+            	closetime, 
+            	description
+			) VALUES (?, ?, ?, ? ,? ,?, ?);
+			`,
+			[ name, location, main_img, user_id, opentime, closetime, description ]
+	  	);
+	} catch (err) {
+		const error = new Error('INVALID_DATA_INPUT');
+		error.statusCode = 500;
+		throw error;
+	}
+};
+
+const dateNameLocationCheck = async (name, location) => {
+	const [dateInfoCheck] = await AppDataSource.query(
+		`SELECT
+			d.name,
+			d.location
+		FROM date d
+		WHERE d.name='${name}' AND d.location='${location}'
+		`
+	);
+	return dateInfoCheck;
+};
+
+const dateLocationCheck = async (location) => {
+	const [dateLocationCheck] = await AppDataSource.query(
+		`SELECT
+			d.location
+		FROM date d
+		WHERE d.location='${location}'
+		`
+	);
+	return dateLocationCheck;
+};
+
+const postCategory = async (category_id) => {
+	try {
+		return await AppDataSource.query(
+			`INSERT INTO date_category(
+				date_id,
+				category_id
+			) VALUES (LAST_INSERT_ID(),?)
+			`,
+			[category_id]
+		)
+	} catch (err) {
+		const error = new Error('INVALID_DATA_INPUT');
+		error.statusCode = 500;
+		throw error;
+	}
+};
+
+const categoryCheck = async (category_id) => {
+    const [categoryId] = await AppDataSource.query(
+        `SELECT 
+			dc.category_id
+		FROM date_category dc
+		WHERE dc.date_id=(LAST_INSERT_ID()) AND dc.category_id='${category_id}'
+        `
+    );
+    return categoryId;
+};
+
+module.exports = {
+    postDate,
+	dateNameLocationCheck,
+	dateLocationCheck,
+	postCategory,
+	categoryCheck
+};

--- a/src/routes/dateRouter.js
+++ b/src/routes/dateRouter.js
@@ -1,0 +1,11 @@
+const express = require('express');
+const router = express.Router();
+
+const dateController = require("../controllers/dateController")
+
+router.post("/adddate",dateController.postDate)
+router.post("/addcategory",dateController.postCategory)
+
+module.exports = {
+    router,
+};

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -4,4 +4,7 @@ const router = express.Router();
 const userRouter = require('./userRouter');
 router.use("/user", userRouter.router);
 
+const dateRouter = require('./dateRouter');
+router.use("/date", dateRouter.router);
+
 module.exports = router;

--- a/src/services/dateService.js
+++ b/src/services/dateService.js
@@ -1,0 +1,32 @@
+const dateDao = require('../models/dateDao');
+
+const postDate = async (name, location, main_img, user_id, opentime, closetime, description) => {
+    const dateNameLocationCheck = await dateDao.dateNameLocationCheck(name, location);
+    const dateLocationCHeck = await dateDao.dateLocationCheck(location);
+    if (dateNameLocationCheck) {
+        const err = new Error("중복된 정보입니다.")
+        err.statusCode = 409;
+        throw err}
+    else if(dateLocationCHeck) {
+        const err = new Error("다른 이름으로 등록된 장소입니다.")
+        err.statusCode = 409;
+        throw err};
+    const postDate = await dateDao.postDate(name, location, main_img, user_id, opentime, closetime, description);
+    return postDate;
+};
+
+const postCategory = async (category_id) => {
+    const categoryCheck = await dateDao.categoryCheck(category_id);
+    if (categoryCheck) {
+        const err = new Error("중복된 카테고리입니다.");
+        err.statusCode = 409;
+        throw err;
+    };
+    const postCategory = await dateDao.postCategory(category_id);
+    return postCategory;
+};
+
+module.exports = {
+    postDate,
+    postCategory,
+};

--- a/src/services/userService.js
+++ b/src/services/userService.js
@@ -17,7 +17,8 @@ const signUp = async (email, password, name) => {
       }
 
     const hashedPassword = await bcrypt.hash(password, 10);
-    await userDao.userSignUp(email, hashedPassword, name);
+    const signup = await userDao.userSignUp(email, hashedPassword, name);
+    return signup;
 };
 
 const signIn = async (email, password) => {


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [x] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 
- 데이트 장소 등록.

<br />

## :: 구현 사항 설명.
1. 중복된 정보 확인후 장소등록.
- 상호명과 주소 두가지의 값이 중복된다면 "중복된 정보입니다" 출력.
- 주소가 중복시 "다른 이름으로 등록된 장소입니다" 출력.

2. 데이트 장소 카테고리 등록.
- 해당 장소의 카테고리 정보 등록.
- 중복된 카테고리 정보 확인.

<br />

## :: 블로커
- 한 장소에 여러 카테고리 저장시 먼저 데이트 장소 정보를 입력 후 그 ID값을 GET하여 카테고리에 POST방식으로 진행하려 했으나 한 작업에 여러 통신이 발생하여 다른 방안 모색.
- LAST_INSERT_ID() 함수 사용하여 여러 카테고리 저장시 date_category테이블의 ID를 가져오는 상황 발생.
ex - ID:82의 데이트 장소릐 카테고리 3,4 입력시 
<img src="https://img1.daumcdn.net/thumb/R1280x0/?scode=mtistory2&fname=https%3A%2F%2Fblog.kakaocdn.net%2Fdn%2FbMI4z2%2FbtrXWKdPxwW%2FIfB12oid0mRLcd3hrLYoH1%2Fimg.png">


<br />

## :: 블로커 해결방안.
- LAST_INSERT_ID() 함수를 통해 중간의 GET과정을 생략이 가능해져 통신의 횟수 감수.
- date_category 테이블의 ID 칼럼 삭제.(다대다의 관계의 경우 별도의 ID. 칼럼 불필요.)
<img src="https://img1.daumcdn.net/thumb/R1280x0/?scode=mtistory2&fname=https%3A%2F%2Fblog.kakaocdn.net%2Fdn%2Fb3djYY%2FbtrXUqVnoGL%2FSbufxgX8ddd587L8Q02d80%2Fimg.png">

<br />

## :: 추후 예상되는 블로커
- 트래픽 증가시 여러 데이트 장소와 카테고리 등록 사이에 다른 api가 통신되에 AUTO_INCREMENT로 등록되는 ID 존재시 LAST_INSERT_ID에 영향을 끼쳐 카테고리 정보 입력에 문제가 발생가능할 수 있다. 

해결방안
 - 퉁신이 많더라도 장소를 POST, ID GET, 카테고리 POST 방식이용.
 - 처음 장소를 등록시 아무런 정보 없이 POST 후 , 나머지 정보를 UPDATE를 사용하여 수정으로 입력. - 유저의 경우 정보 등록으로 인지(원티드 이력서 등록 방식.)