### PR TITLE
[ADD] 데이트장소 삭제

### DIFF
--- a/src/controllers/dateController.js
+++ b/src/controllers/dateController.js
@@ -69,7 +69,7 @@ const recommendRandom = async (req,res) => {
 
 const updateDate = async (req,res) => {
     try{
-        const dateId = req.params.dateid;
+        const { dateId }= req.params;
         const { name, location, description, opentime, closetime} = req.body;
         await dateService.updateDate(dateId, name, location, description, opentime, closetime);
         res.status(201).json({ message: "정보가 수정되었습니다."});
@@ -82,10 +82,22 @@ const updateDate = async (req,res) => {
 
 const deleteCategory = async(req,res) => {
     try{
-        const dateId = req.params.dateid;
-        const categoryId = req.body.categoryId;
+        const { dateId } = req.params;
+        const { categoryId } = req.body;
         await dateService.deleteCategory(dateId,categoryId);
         res.status(201).json({ message: "해당 카테고리가 삭제되었습니다."});
+    } catch (err) {
+        res
+        .status(err.statusCode ? err.statusCode : 400)
+        .json({ message: err.message });
+    }
+};
+
+const deleteDate = async(req,res) => {
+    try{
+        const { dateId }= req.params;
+        await dateService.deleteDate(dateId);
+        res.status(201).json({ message: "해당 데이트장소가 삭제되었습니다."});
     } catch (err) {
         res
         .status(err.statusCode ? err.statusCode : 400)
@@ -101,5 +113,6 @@ module.exports = {
     recommendManyDate,
     recommendRandom,
     updateDate,
-    deleteCategory
+    deleteCategory,
+    deleteDate
 };

--- a/src/models/dateDao.js
+++ b/src/models/dateDao.js
@@ -180,6 +180,34 @@ const deleteCategory = async (dateId, categoryId) => {
 	}
 };
 
+const deleteDate = async (dateId) => {
+	try{
+		return await AppDataSource.query(
+			`DELETE FROM date
+				WHERE id = '${dateId}'
+			`
+		);
+	} catch (err) {
+		const error = new Error(err,'INVALID_DATA_INPUT');
+		error.statusCode = 500;
+		throw error;
+	}
+};
+
+const deleteAllCategory = async (dateId) => {
+	try{
+		return await AppDataSource.query(
+			`DELETE FROM date_category
+				WHERE date_id = '${dateId}'
+			`
+		);
+	} catch (err) {
+		const error = new Error(err,'INVALID_DATA_INPUT');
+		error.statusCode = 500;
+		throw error;
+	}
+};
+
 module.exports = {
     postDate,
 	dateNameLocationCheck,
@@ -190,5 +218,7 @@ module.exports = {
 	recommendDate,
 	recommendRandom,
 	updateDate,
-	deleteCategory
+	deleteCategory,
+	deleteDate,
+	deleteAllCategory
 };

--- a/src/routes/dateRouter.js
+++ b/src/routes/dateRouter.js
@@ -9,8 +9,9 @@ router.get("/list",dateController.getDateList)
 router.get("/recommend",dateController.recommendDate)  //지역과 카테고리 하나만 설정가능
 router.get("/recommendmany",dateController.recommendManyDate)  //recommend 3번 반복.
 router.get("/randomrecommed",dateController.recommendRandom)  // 완전랜덤 추천
-router.patch("/:dateid",dateController.updateDate)
-router.delete("/updatecategory/:dateid",dateController.deleteCategory)
+router.patch("/:dateId",dateController.updateDate)
+router.delete("/updatecategory/:dateId",dateController.deleteCategory)
+router.delete("/:dateId",dateController.deleteDate)
 
 module.exports = {
     router,

--- a/src/services/dateService.js
+++ b/src/services/dateService.js
@@ -53,11 +53,16 @@ const recommendRandom = async() => {
 };
 
 const updateDate = async(dateId, name, location, description, opentime, closetime) => {
-    return dateDao.updateDate(dateId, name, location, description, opentime, closetime)
+    return await dateDao.updateDate(dateId, name, location, description, opentime, closetime)
 };
 
 const deleteCategory = async(dateId, categoryId) => {
-    return dateDao.deleteCategory(dateId, categoryId);
+    return await dateDao.deleteCategory(dateId, categoryId);
+};
+
+const deleteDate = async(dateId) => {
+    await dateDao.deleteDate(dateId);
+    await dateDao.deleteAllCategory(dateId);
 };
 
 module.exports = {
@@ -68,5 +73,6 @@ module.exports = {
     recommendManyDate,
     recommendRandom,
     updateDate,
-    deleteCategory
+    deleteCategory,
+    deleteDate
 };


### PR DESCRIPTION
## :: 최근 작업 주제
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 
1. 데이트 장소 삭제

<br />

## :: 구현 사항 설명.
1. 데이트 장소 삭제
- 데이트 장소 id 입력시 해당 장소 및 카테고리 삭제

<br />

## :: 개발상황
1. 데이트 장소 삭제시 카테고리의 삭제.
- 현재 테이블들의 외래키를 끊은 상태여서 데이트 장소만을 삭제해서는 카테고리 정보가 삭제되지 않는다.
위 방법은 관계가 많지 않거나 해당 서비스의 반응을 확인하고 빠른 대처 및 수정간에 불필요함이있어 추후 일정이상이 지나면 연결 예정이다.(-현업에서 사용중.)

<br />

## :: 추후 예상되는 블로커
1. 데이트 장소 삭제시 하위 내용들(추가될 리뷰 및 평점)의 삭제.
- 이 개발의 취지는 많은 사람들이 자신이 경험했던 데이트 장소를 등록하고 다른 사람들에게 추천 및 반응을 받는 것인데
만약 처음 데이트 장소를 게시한 유저가 그 장소를 삭제한다면 그 밑에 달리는 리뷰 및 정보들이 삭제된다.(외래키 설정시).

## :: 블로커 해결방안.
1. 업체들의 관리자 계정 생성.
- 업체들이 자신의 가게 계정을 생성하는 것이 첫번쨰 방법이다.
하지만 해당 방법의 경우 평점 관리 및 리뷰관리가 들어갈 수 있고 만약 업체가 등록하지 않는다면 추천 및 정보를 등록이 불가하다.

2. 관리자의 허가 기능 추가.
- 유저가 데이트 장소를 등록시 관리자가 확인하고 블린(boolean)값을 변경하여 인증해주는 방법이다.
하지만 해당 방법의 경우 신규 업체 및 검색정보가 별로 없는 가게의 경우 등록이 늦어지며 삭제또한 관리자 확인 절차를 넣게된다면 해당 정보만을 계속해서 확인 업무를 진행해야한다.
